### PR TITLE
Fixed checkbox validation

### DIFF
--- a/ang/crmFieldMetadata/crmRenderCheckbox.html
+++ b/ang/crmFieldMetadata/crmRenderCheckbox.html
@@ -1,3 +1,4 @@
+<!-- TODO: Is this necessary? Under what circumstances would there be no options? -->
 <input ng-if="!field.options.length" type="checkbox" ng-model="$parent.model"  name="{{field.name}}" id="{{prefix}}{{field.name}}" ng-required="field.required" />
 
 <!-- Because we are using multiple HTML elements (the checkboxes) to represent

--- a/ang/crmFieldMetadata/crmRenderCheckbox.html
+++ b/ang/crmFieldMetadata/crmRenderCheckbox.html
@@ -1,17 +1,21 @@
 <!-- TODO: Is this necessary? Under what circumstances would there be no options? -->
 <input ng-if="!field.options.length" type="checkbox" ng-model="$parent.model"  name="{{field.name}}" id="{{prefix}}{{field.name}}" ng-required="field.required" />
 
-<!-- Because we are using multiple HTML elements (the checkboxes) to represent
-     a single model (the array of selections for this field as returned by
-     CiviCRM's API), the checkbox inputs below are bound to their model
-     manually using ng-click, ng-checked, and ng-required. For ng-required to be
-     useful, the checkbox elements must have an ng-model set, as the field is
-     only flagged as invalid if the "required" attribute is set AND calling
-     NgModelController.$isEmpty returns true. If ng-model is not set, the
-     field is always considered valid. However, setting ng-model would interfere
-     with our manual model management because Angular's automatic binding would
-     kick in. Setting the model option updateOn to an empty string effectively
-     turns off Angular's binding magic.
+<!-- Typically in an Angular application, models and the state of related
+     interface elements are automagically synced. When there is a one-to-one
+     relationship between models and UI elements, this is convenient. Because we
+     are using multiple HTML elements (the checkboxes) to represent individual
+     items in a single model (the array of selections for this field as returned
+     by CiviCRM's API), we need to do some extra work. We disable model updates
+     for these elements and manage the sync using ng-click, ng-checked, and
+     ng-required. Per the Angular doc, model updates can be limited to certain
+     events (click, blur, etc.) using the updateOn property of the object passed
+     to the ng-model-options directive; setting this to an empty string (not
+     documented) disables them altogether. Note: for a checkbox the field
+     validity is determined by both whether the "required" attribute is set (by
+     ng-required in our case) and by the value of NgModelController.$isEmpty
+     (which evaluates ng-model), so it is important that checkbox element's
+     ng-model reflect the whole group of checkboxes.
 -->
 <div ng-if="field.options.length" ng-repeat="option in field.options">
   <input type="checkbox" id="{{prefix}}{{field.name}}_{{option.value}}" name="{{option.name}}"

--- a/ang/crmFieldMetadata/crmRenderCheckbox.html
+++ b/ang/crmFieldMetadata/crmRenderCheckbox.html
@@ -1,7 +1,8 @@
 <input ng-if="!field.options.length" type="checkbox" ng-model="$parent.model"  name="{{field.name}}" id="{{prefix}}{{field.name}}" ng-required="field.required" />
 
 <div ng-if="field.options.length" ng-repeat="option in field.options">
-  <input type="checkbox" ng-model="$parent.model[option.value]" id="{{prefix}}{{field.name}}_{{option.value}}" name="{{option.name}}" ng-required="option.required" />
+  <input type="checkbox" id="{{prefix}}{{field.name}}_{{option.value}}" name="{{option.name}}"
+         ng-click="handleToggle(option.value)" ng-checked="isChecked(option.value)" ng-required="isRequired()" />
   <label for="{{prefix}}{{field.name}}_{{option.value}}">
     <span ng-if="option.preText" class="crm-help-pre description">{{option.preText}}:</span>
     {{option.label}}

--- a/ang/crmFieldMetadata/crmRenderCheckbox.html
+++ b/ang/crmFieldMetadata/crmRenderCheckbox.html
@@ -1,7 +1,20 @@
 <input ng-if="!field.options.length" type="checkbox" ng-model="$parent.model"  name="{{field.name}}" id="{{prefix}}{{field.name}}" ng-required="field.required" />
 
+<!-- Because we are using multiple HTML elements (the checkboxes) to represent
+     a single model (the array of selections for this field as returned by
+     CiviCRM's API), the checkbox inputs below are bound to their model
+     manually using ng-click, ng-checked, and ng-required. For ng-required to be
+     useful, the checkbox elements must have an ng-model set, as the field is
+     only flagged as invalid if the "required" attribute is set AND calling
+     NgModelController.$isEmpty returns true. If ng-model is not set, the
+     field is always considered valid. However, setting ng-model would interfere
+     with our manual model management because Angular's automatic binding would
+     kick in. Setting the model option updateOn to an empty string effectively
+     turns off Angular's binding magic.
+-->
 <div ng-if="field.options.length" ng-repeat="option in field.options">
   <input type="checkbox" id="{{prefix}}{{field.name}}_{{option.value}}" name="{{option.name}}"
+         ng-model="model" ng-model-options="{updateOn: ''}"
          ng-click="handleToggle(option.value)" ng-checked="isChecked(option.value)" ng-required="isRequired()" />
   <label for="{{prefix}}{{field.name}}_{{option.value}}">
     <span ng-if="option.preText" class="crm-help-pre description">{{option.preText}}:</span>

--- a/ang/crmFieldMetadata/crmRenderCheckbox.js
+++ b/ang/crmFieldMetadata/crmRenderCheckbox.js
@@ -10,15 +10,27 @@
       templateUrl: '~/crmFieldMetadata/crmRenderCheckbox.html',
       controller: ['$scope', function crmRenderCheckboxController($scope) {
         $scope.formatMoney = CRM.formatMoney;
-        //if the model is undefined (eg an undefined key on an object
-        //AND we have multiple options, set the base model to an object
-        //so that the bindings work.
-        if (typeof($scope.model) === "undefined" && $scope.field.options.length > 0) {
-          $scope.model = {};
-          _.each($scope.field.options, function(option) {
-            $scope.model[option.value] = !!option.default;
-          });
+        $scope.handleToggle = function (value) {
+          var i = $scope.model.indexOf(value);
+          if (i === -1) {
+            $scope.model.push(value);
+          } else {
+            $scope.model.splice(i, 1);
+          }
+        };
+        $scope.isChecked = function (value) {
+          return ($scope.model.indexOf(value) === -1 ? false : true);
+        };
+        $scope.isRequired = function () {
+          return $scope.field.required && ($scope.model.length === 0);
+        };
 
+        // Checkboxes are modeled as Arrays because multiple selections can be
+        // made. However, if we are retrieving a set of checkboxes for which no
+        // selections have been made, CiviCRM's API represents the field as an
+        // empty string. We standardize the representation here.
+        if (!Array.isArray($scope.model)) {
+          $scope.model = [];
         }
       }]
     };


### PR DESCRIPTION
Without this patch, checkboxes marked as required are not treated as such. With the patch, the field group will be considered invalid until at least one box is checked.

I suspect this patch fixes other (undiscovered/unreported) bugs with the checkbox implementation, as the model seemed... not right.
