### PR TITLE
Fixes #11: Price field radio buttons display amount regardless of configuration

### DIFF
--- a/CRM/Fieldmetadata/Normalizer/PriceSet.php
+++ b/CRM/Fieldmetadata/Normalizer/PriceSet.php
@@ -36,7 +36,7 @@ class CRM_Fieldmetadata_Normalizer_PriceSet extends CRM_Fieldmetadata_Normalizer
           $field["defaultValue"] = "";
           $field["preText"] = CRM_Utils_Array::value("help_pre", $priceField, "");
           $field["postText"] = CRM_Utils_Array::value("help_post", $priceField, "");
-          $field["displayPrice"] = $priceField['is_display_amounts'];
+          $field["displayPrice"] = $this->normalizeBoolean($priceField['is_display_amounts']);
           $field["quantity"] = ($priceField['is_enter_qty'] == 1);
 
 

--- a/ang/crmFieldMetadata/crmRenderCheckbox.html
+++ b/ang/crmFieldMetadata/crmRenderCheckbox.html
@@ -24,7 +24,7 @@
   <label for="{{prefix}}{{field.name}}_{{option.value}}">
     <span ng-if="option.preText" class="crm-help-pre description">{{option.preText}}:</span>
     {{option.label}}
-    <span ng-if="option.price" class="crm-price-amount-amount"> - {{formatMoney(option.price)}}</span>
+    <span ng-if="option.price && field.displayPrice" class="crm-price-amount-amount"> - {{formatMoney(option.price)}}</span>
     <span ng-if="option.postText" class="crm-help-post description">:{{option.postText}}</span>
   </label>
 </div>

--- a/ang/crmFieldMetadata/crmRenderRadio.html
+++ b/ang/crmFieldMetadata/crmRenderRadio.html
@@ -3,7 +3,7 @@
   <label for="{{prefix}}{{field.name}}_{{option.value}}">
     <span ng-if="option.preText" class="crm-help-pre description">{{option.preText}}:</span>
     {{option.label}}
-    <span ng-if="option.price" class="crm-price-amount-amount"> - $ {{option.price}}</span>
+    <span ng-if="option.price && field.displayPrice" class="crm-price-amount-amount"> - $ {{option.price}}</span>
     <span ng-if="option.postText" class="crm-help-post description">:{{option.postText}}</span>
   </label>
 </div>

--- a/ang/crmFieldMetadata/crmRenderWidget.js
+++ b/ang/crmFieldMetadata/crmRenderWidget.js
@@ -10,8 +10,7 @@
         prefix: '='
       },
       link: function(scope, elem, attrs) {
-        //console.log(scope.field.widget);
-        scope.field.displayPrice = (scope.field.displayPrice == 1);
+        scope.field.displayPrice = (scope.field.displayPrice === '1');
         var childEl;
         switch (scope.field.widget) {
           case "crm-ui-datepicker":


### PR DESCRIPTION
Based on a read of the code, checkboxes were also affected by this bug. The fundamental problem was that the widget templates didn't take the displayPrice property into account. For consistency, I updated the normalizer to use the new normalizeBoolean() method, reducing doubt on the client side about the return format.