### PR TITLE
Fixes regression caused by 4351c6c.

### DIFF
--- a/ang/crmFieldMetadata/crmRenderField.js
+++ b/ang/crmFieldMetadata/crmRenderField.js
@@ -10,7 +10,13 @@
       },
       templateUrl: '~/crmFieldMetadata/crmRenderField.html',
       controller: ['$scope', '$element', '$sce', function crmRenderFieldController($scope, $element, $sce) {
-        $scope.field.required = ($scope.field.required === '1');
+        // Because of differences between how PHP and JS evaluate strings (e.g.,
+        // in JS '0' is considered truthy), the client is very strict in how it
+        // determines whether or not a field is required. '1' means the
+        // fieldmetadata API reported the field as required. Boolean true means
+        // the client has already determined that the field is required (this
+        // ensures idempotence). Anything else is considered not required.
+        $scope.field.required = ($scope.field.required === '1' || $scope.field.required === true);
         $element.addClass('crm-section');
         $scope.preText = $sce.trustAsHtml($scope.field.preText);
         $scope.postText = $sce.trustAsHtml($scope.field.postText);


### PR DESCRIPTION
In addressing issue #7, pull request #8, which corrected a problem in which
fields are sometimes marked as required when they shouldn't be, introduced
some non-idempotent code which resulted in required fields being rendered as
non-required in some cases. This patch makes the code idempotent and thus
fixes the bug.