### PR TITLE
Resolves #20: Add metadata about field visibility.

### DIFF
--- a/CRM/Fieldmetadata/Normalizer/PriceSet.php
+++ b/CRM/Fieldmetadata/Normalizer/PriceSet.php
@@ -38,7 +38,7 @@ class CRM_Fieldmetadata_Normalizer_PriceSet extends CRM_Fieldmetadata_Normalizer
           $field["postText"] = CRM_Utils_Array::value("help_post", $priceField, "");
           $field["displayPrice"] = $this->normalizeBoolean($priceField['is_display_amounts']);
           $field["quantity"] = ($priceField['is_enter_qty'] == 1);
-
+          $field["visibility"] = $priceField['visibility_id'];
 
           $field['widget'] = $priceField['html_type'];
 

--- a/CRM/Fieldmetadata/Normalizer/UFGroup.php
+++ b/CRM/Fieldmetadata/Normalizer/UFGroup.php
@@ -34,6 +34,7 @@ class CRM_Fieldmetadata_Normalizer_UFGroup extends CRM_Fieldmetadata_Normalizer 
       $field["defaultValue"] = "";
       $field["preText"] = CRM_Utils_Array::value("help_pre", $fieldData, "");
       $field["postText"] = CRM_Utils_Array::value("help_post", $fieldData, "");
+      $field["visibility"] = $fieldData['visibiility'];
 
       //todo: Use either the html_type or the data type
       $field['widget'] = $fieldData['html_type'];


### PR DESCRIPTION
This pull request is a light-lift approach to providing visibility metadata for fields. Ideally I'd like to refactor this extension and deal with a Field class rather than a field array, but that kind of refactoring is out of scope for the moment.

I found two types of entities which have visibility metadata: PriceField and UFField. They have different property names for visibility, and they represent the values in different ways: one uses a human-readable string; the other uses an optionGroup.

I made a few decisions:
* As a consumer of the API, I'd rather deal with a human-readable return value than a magic number or a reference to an optionValue.
* Some of the possible values across type are equivalent, so I consolidated them.

Here is what users of the API should expect with regard to the value of visibility:

* Value _admin_: only admins can use this field for input or view its value (admins can access fields with any visibility)
* Value _public_: anyone can use this field for input; fields which don't have a visibility property will return this
* Value _public_and_listings_: anyone can use this field for input or view its value (e.g., in a profile)
* Value _user_: only the user this field is about can use this field for input
* Values added to the "visibility" option group can also be returned (by name).
* Any other strings will be returned as-is (e.g., if someone were to hack civicrm_uf_field.visibility).