### PR TITLE
Added collectionId to the result for each entity type.

### DIFF
--- a/CRM/Fieldmetadata/Fetcher/BillingBlock.php
+++ b/CRM/Fieldmetadata/Fetcher/BillingBlock.php
@@ -10,7 +10,7 @@ class CRM_Fieldmetadata_Fetcher_BillingBlock extends CRM_Fieldmetadata_Fetcher {
 
   function fetch(&$params) {
     $data = array();
-    $id = CRM_Utils_Array::value("id", $params);
+    $data['id'] = $id = CRM_Utils_Array::value("id", $params);
     $bltId = CRM_Core_BAO_LocationType::getBilling();
 
     //fetch the payment processor

--- a/CRM/Fieldmetadata/Normalizer/BillingBlock.php
+++ b/CRM/Fieldmetadata/Normalizer/BillingBlock.php
@@ -10,6 +10,7 @@ class CRM_Fieldmetadata_Normalizer_BillingBlock extends CRM_Fieldmetadata_Normal
 
   function normalizeData(&$data, $params) {
     $return = array(
+      "collectionId" => $data['id'],
       "collectionType" => "BillingBlock",
       "title" => $data['title'],
       "name" => $data['name'],

--- a/CRM/Fieldmetadata/Normalizer/CustomGroup.php
+++ b/CRM/Fieldmetadata/Normalizer/CustomGroup.php
@@ -9,6 +9,7 @@ class CRM_Fieldmetadata_Normalizer_CustomGroup extends CRM_Fieldmetadata_Normali
 
   function normalizeData(&$data, $params) {
     $return = array(
+      "collectionId" => $data['id'],
       "collectionType" => "CustomGroup",
       "title" => $data['title'],
       "name" => $data['name'],

--- a/CRM/Fieldmetadata/Normalizer/PaymentBlock.php
+++ b/CRM/Fieldmetadata/Normalizer/PaymentBlock.php
@@ -10,6 +10,7 @@ class CRM_Fieldmetadata_Normalizer_PaymentBlock extends CRM_Fieldmetadata_Normal
 
   function normalizeData(&$data, $params) {
     $return = array(
+      "collectionId" => $data['id'],
       "collectionType" => "PaymentBlock",
       "title" => $data['title'],
       "name" => $data['class_name'],

--- a/CRM/Fieldmetadata/Normalizer/PriceSet.php
+++ b/CRM/Fieldmetadata/Normalizer/PriceSet.php
@@ -11,6 +11,7 @@ class CRM_Fieldmetadata_Normalizer_PriceSet extends CRM_Fieldmetadata_Normalizer
   function normalizeData(&$data, $params) {
 
     $return = array(
+      "collectionId" => $data['id'],
       "collectionType" => "PriceSet",
       "title" => $data['title'],
       "name" => $data['name'],

--- a/CRM/Fieldmetadata/Normalizer/UFGroup.php
+++ b/CRM/Fieldmetadata/Normalizer/UFGroup.php
@@ -11,6 +11,7 @@ class CRM_Fieldmetadata_Normalizer_UFGroup extends CRM_Fieldmetadata_Normalizer 
   function normalizeData(&$data, $params) {
 
     $return = array(
+      "collectionId" => $data['id'],
       "collectionType" => "UFGroup",
       "title" => $data['title'],
       "name" => $data['name'],


### PR DESCRIPTION
Provides essential metadata (namely, the ID of the entity in question) to the result.

Improves the developer experience for downstream developers, especially for those working in AngularJS. Without this change, developers have to jump through unnecessary hoops to get the complete picture, e.g.:

```javascript
// without this change
let params = {
  entity: 'UFGroup',
  entity_params: {id: 44}
};
let metadata = crmApi('Fieldmetadata', params).then(function (result) {
  result.collectionId = 44;
  return result;
});

// with this change
let params = {
  entity: 'UFGroup',
  entity_params: {id: 44}
};
let metadata = crmApi('Fieldmetadata', params);
```

Although I don't think I've seen the following use case in the wild and I doubt it's been tested thoroughly, the API _does_ allow passing arbitrary `entity_params`. In the case of a request such as:

```javascript
let params = {
  entity: 'UFGroup',
  entity_params: {name: 'machine_name_of_my_important_profile'}
};
let metadata = crmApi('Fieldmetadata', params);
```

... there is currently no way to get the entity ID.